### PR TITLE
[RSK-20] - Remove Customizations from the generated SDK project

### DIFF
--- a/EdFi.Roster.Sdk/Client/ApiClient.cs
+++ b/EdFi.Roster.Sdk/Client/ApiClient.cs
@@ -391,8 +391,7 @@ namespace EdFi.Roster.Sdk.Client
             var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>(), result, rawContent)
             {
                 ErrorText = response.ErrorMessage,
-                Cookies = new List<Cookie>(),
-                ResponseUri = response.ResponseUri // Customization to set ResponseUri property  
+                Cookies = new List<Cookie>()
             };
 
             if (response.Headers != null)

--- a/EdFi.Roster.Sdk/Client/ApiResponse.cs
+++ b/EdFi.Roster.Sdk/Client/ApiResponse.cs
@@ -55,11 +55,6 @@ namespace EdFi.Roster.Sdk.Client
         /// The raw content of this response
         /// </summary>
         string RawContent { get; }
-
-        /// <summary>
-        /// Customized property added to keep track of the response uri
-        /// </summary>
-        public Uri ResponseUri { get; set; }
     }
 
     /// <summary>
@@ -118,12 +113,6 @@ namespace EdFi.Roster.Sdk.Client
         /// </summary>
         public string RawContent { get; }
 
-
-        /// <summary>
-        /// Customized property added to keep track of the response uri
-        /// </summary>
-        public Uri ResponseUri { get; set; }
-
         #endregion Properties
 
         #region Constructors
@@ -135,14 +124,12 @@ namespace EdFi.Roster.Sdk.Client
         /// <param name="headers">HTTP headers.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
         /// <param name="rawContent">Raw content.</param>
-        /// <param name="responseUri">Response Uri</param>
-        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data, string rawContent, Uri responseUri)
+        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data, string rawContent)
         {
             StatusCode = statusCode;
             Headers = headers;
             Data = data;
             RawContent = rawContent;
-            ResponseUri = responseUri;
         }
 
         /// <summary>
@@ -151,7 +138,7 @@ namespace EdFi.Roster.Sdk.Client
         /// <param name="statusCode">HTTP status code.</param>
         /// <param name="headers">HTTP headers.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
-        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data) : this(statusCode, headers, data, null, null)
+        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data) : this(statusCode, headers, data, null)
         {
         }
 
@@ -171,28 +158,6 @@ namespace EdFi.Roster.Sdk.Client
         /// <param name="statusCode">HTTP status code.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
         public ApiResponse(HttpStatusCode statusCode, T data) : this(statusCode, data, null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
-        /// </summary>
-        /// <param name="statusCode">HTTP status code.</param>
-        /// <param name="headers">HTTP headers.</param>
-        /// <param name="data">Data (parsed HTTP body)</param>
-        /// <param name="responseUri">Response Uri</param>
-        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data, Uri responseUri) : this(statusCode, headers, data, null, responseUri)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
-        /// </summary>
-        /// <param name="statusCode">HTTP status code.</param>
-        /// <param name="headers">HTTP headers.</param>
-        /// <param name="data">Data (parsed HTTP body)</param>
-        /// <param name="rawContent">Raw content.</param>
-        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data, string rawContent) : this(statusCode, headers, data, rawContent, null)
         {
         }
 

--- a/EdFi.Roster.Services/ApiSdk/ApiFacade.cs
+++ b/EdFi.Roster.Services/ApiSdk/ApiFacade.cs
@@ -1,16 +1,20 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace EdFi.Roster.Services.ApiSdk
 {
     public interface IApiFacade
     {
         Task<T> GetApiClassInstance<T>(bool refreshToken = false);
+        Uri BuildResponseUri(string apiRoute, int offset, int limit);
     }
 
     public class ApiFacade : IApiFacade
     {
         private readonly IConfigurationService _configurationService;
+        private string BasePath { get; set; }
 
         public ApiFacade(IConfigurationService configurationService)
         {
@@ -20,7 +24,16 @@ namespace EdFi.Roster.Services.ApiSdk
         public async Task<T> GetApiClassInstance<T>(bool refreshToken = false)
         {
             var apiConfiguration = await _configurationService.ApiConfiguration(refreshToken);
+            BasePath = apiConfiguration.BasePath;
             return (T)Activator.CreateInstance(typeof(T), apiConfiguration);
+        }
+
+        public Uri BuildResponseUri(string apiRoute, int offset, int limit)
+        {
+            var url = $"{BasePath}/{apiRoute}";
+            var queryParams = new Dictionary<string, string> { { "offset", offset.ToString() }, { "limit", limit.ToString() } };
+
+            return new Uri(QueryHelpers.AddQueryString(url, queryParams), UriKind.Absolute);
         }
     }
 }

--- a/EdFi.Roster.Services/ApiSdk/ApiRoutes.cs
+++ b/EdFi.Roster.Services/ApiSdk/ApiRoutes.cs
@@ -1,0 +1,11 @@
+﻿namespace EdFi.Roster.Services.ApiSdk
+{
+    public static class ApiRoutes
+    {
+        public static string LocalEducationAgencies => "ed-fi/enrollment/LocalEducationAgencies";
+        public static string Schools => "ed-fi/enrollment/Schools";
+        public static string Staffs => "ed-fi/enrollment/Staffs";
+        public static string Students => "ed-fi/enrollment/Students";
+        public static string Sections => "ed-fi/enrollment/Sections";
+    }
+}

--- a/EdFi.Roster.Services/BearerTokenService.cs
+++ b/EdFi.Roster.Services/BearerTokenService.cs
@@ -46,9 +46,7 @@ namespace EdFi.Roster.Services
 
             //return results
             return new ApiResponse<BearerTokenResponse>(bearerTokenResponse.StatusCode,
-                headersMap,
-                (BearerTokenResponse)bearerTokenResponse.Data,
-                bearerTokenResponse.ResponseUri);
+                headersMap, bearerTokenResponse.Data);
         }
 
         private async Task LogDetails(IRestRequest bearerTokenRequest, IRestResponse<BearerTokenResponse> bearerTokenResponse)

--- a/EdFi.Roster.Services/EdFi.Roster.Services.csproj
+++ b/EdFi.Roster.Services/EdFi.Roster.Services.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.5" />
   </ItemGroup>

--- a/EdFi.Roster.Services/IResponseHandleService.cs
+++ b/EdFi.Roster.Services/IResponseHandleService.cs
@@ -9,7 +9,7 @@ namespace EdFi.Roster.Services
 {
     public interface IResponseHandleService
     {
-        Task<ExtendedInfoResponse<List<T>>> Handle<T>(ApiResponse<List<T>> apiResponse, ExtendedInfoResponse<List<T>> response, string errorMessage)
+        Task<ExtendedInfoResponse<List<T>>> Handle<T>(ApiResponse<List<T>> apiResponse, ExtendedInfoResponse<List<T>> response, Uri responseUri, string errorMessage)
             where T : class;
     }
 
@@ -23,12 +23,12 @@ namespace EdFi.Roster.Services
         }
 
         public async Task<ExtendedInfoResponse<List<T>>> Handle<T>(ApiResponse<List<T>> apiResponse, 
-            ExtendedInfoResponse<List<T>> response, string errorMessage) where T : class
+            ExtendedInfoResponse<List<T>> response, Uri responseUri, string errorMessage) where T : class
         {
             var responsePage = new ExtendedInfoResponsePage
             {
                 RecordsCount = apiResponse.Data.Count,
-                ResponseUri = apiResponse.ResponseUri
+                ResponseUri = responseUri
             };
             response.GeneralInfo.Pages.Add(responsePage);
             response.FullDataSet.AddRange(apiResponse.Data);
@@ -42,7 +42,7 @@ namespace EdFi.Roster.Services
                 Content = string.IsNullOrEmpty(errorMessage)
                     ? JsonConvert.SerializeObject(apiResponse.Data, Formatting.Indented)
                     : errorMessage,
-                Uri = apiResponse.ResponseUri.ToString()
+                Uri = responseUri.ToString()
             };
             await _logService.WriteLog(apiLogEntry);
 

--- a/EdFi.Roster.Services/LocalEducationAgencyService.cs
+++ b/EdFi.Roster.Services/LocalEducationAgencyService.cs
@@ -51,6 +51,7 @@ namespace EdFi.Roster.Services
             do
             {
                 var errorMessage = string.Empty;
+                var responseUri = _apiFacade.BuildResponseUri(ApiRoutes.LocalEducationAgencies, offset, limit);
                 ApiResponse<List<LocalEducationAgency>> currentApiResponse = null;
                 try
                 {
@@ -70,7 +71,7 @@ namespace EdFi.Roster.Services
                 if (currentApiResponse == null) continue;
                 currResponseRecordCount = currentApiResponse.Data.Count;
                 offset += limit;
-                response = await _responseHandleService.Handle(currentApiResponse, response, errorMessage);
+                response = await _responseHandleService.Handle(currentApiResponse, response, responseUri, errorMessage);
 
             } while (currResponseRecordCount >= limit);
 

--- a/EdFi.Roster.Services/SchoolService.cs
+++ b/EdFi.Roster.Services/SchoolService.cs
@@ -51,6 +51,7 @@ namespace EdFi.Roster.Services
             do
             {
                 var errorMessage = string.Empty;
+                var responseUri = _apiFacade.BuildResponseUri(ApiRoutes.Schools, offset, limit);
                 ApiResponse<List<School>> currentApiResponse = null;
                 try
                 {
@@ -70,7 +71,7 @@ namespace EdFi.Roster.Services
                 if (currentApiResponse == null) continue;
                 currResponseRecordCount = currentApiResponse.Data.Count;
                 offset += limit;
-                response = await _responseHandleService.Handle(currentApiResponse, response, errorMessage);
+                response = await _responseHandleService.Handle(currentApiResponse, response, responseUri, errorMessage);
 
             } while (currResponseRecordCount >= limit);
 

--- a/EdFi.Roster.Services/SectionService.cs
+++ b/EdFi.Roster.Services/SectionService.cs
@@ -50,6 +50,7 @@ namespace EdFi.Roster.Services
             do
             {
                 var errorMessage = string.Empty;
+                var responseUri = _apiFacade.BuildResponseUri(ApiRoutes.Sections, offset, limit);
                 ApiResponse<List<Section>> currentApiResponse = null;
                 try
                 {
@@ -69,7 +70,7 @@ namespace EdFi.Roster.Services
                 if (currentApiResponse == null) continue;
                 currResponseRecordCount = currentApiResponse.Data.Count;
                 offset += limit;
-                response = await _responseHandleService.Handle(currentApiResponse, response, errorMessage);
+                response = await _responseHandleService.Handle(currentApiResponse, response, responseUri, errorMessage);
 
             } while (currResponseRecordCount >= limit);
 

--- a/EdFi.Roster.Services/StaffService.cs
+++ b/EdFi.Roster.Services/StaffService.cs
@@ -50,6 +50,7 @@ namespace EdFi.Roster.Services
             do
             {
                 var errorMessage = string.Empty;
+                var responseUri = _apiFacade.BuildResponseUri(ApiRoutes.Staffs, offset, limit);
                 ApiResponse<List<Staff>> currentApiResponse = null;
                 try
                 {
@@ -69,7 +70,7 @@ namespace EdFi.Roster.Services
                 if (currentApiResponse == null) continue;
                 currResponseRecordCount = currentApiResponse.Data.Count;
                 offset += limit;
-                response = await _responseHandleService.Handle(currentApiResponse, response, errorMessage);
+                response = await _responseHandleService.Handle(currentApiResponse, response, responseUri, errorMessage);
 
             } while (currResponseRecordCount >= limit);
 

--- a/EdFi.Roster.Services/StudentService.cs
+++ b/EdFi.Roster.Services/StudentService.cs
@@ -50,6 +50,7 @@ namespace EdFi.Roster.Services
             do
             {
                 var errorMessage = string.Empty;
+                var responseUri = _apiFacade.BuildResponseUri(ApiRoutes.Students, offset, limit);
                 ApiResponse<List<Student>> currentApiResponse = null;
                 try
                 {
@@ -69,8 +70,8 @@ namespace EdFi.Roster.Services
                 if (currentApiResponse == null) continue;
                 currResponseRecordCount = currentApiResponse.Data.Count;
                 offset += limit;
-                response = await _responseHandleService.Handle(currentApiResponse, response, errorMessage);
-               
+                response = await _responseHandleService.Handle(currentApiResponse, response, responseUri, errorMessage);
+
             } while (currResponseRecordCount >= limit);
 
             response.GeneralInfo.TotalRecords = response.FullDataSet.Count;

--- a/Readme.md
+++ b/Readme.md
@@ -6,10 +6,28 @@ Ed-Fi Roster Sample Application. This repository is to be used in conjunction wi
 The prerequisites for opening and running this solution are as follows:
 
 * Visual Studio 2019 Community
-* .NET Framework 4.6.1
-    * This is for the SDK generated with Swagger Tools
 * .NET Core 3.1
     * This is for the other projects in the solution
+
+### OpenAPI Generator
+
+The [OpenApi Generator](https://openapi-generator.tech/) is used to generate the SDK project in this repository.
+Following were the steps followed to generate the SDK project:
+
+- Install the openapi-generator JAR file using [wget](http://gnuwin32.sourceforge.net/packages/wget.htm) or Invoke-WebRequest in PowerShell (3.0+), e.g.
+    ```
+    Invoke-WebRequest -OutFile openapi-generator-cli.jar https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.1.1/openapi-generator-cli-5.1.1.jar
+    ```
+- Use the following command to generate the SDK project:
+    ```
+    java -jar openapi-generator-cli.jar generate -g csharp-netcore -i https://api.ed-fi.org/v5.2/api/metadata/composites/v1/ed-fi/enrollment/swagger.json --api-package Api.EnrollmentComposites --model-package Models.EnrollmentComposites -o csharp-netcore --additional-properties=netCoreProjectFile --additional-properties=packageName='EdFi.Roster.Sdk' --additional-properties=targetFramework=netcoreapp3.1 --additional-properties=modelPropertyNaming=PascalCase
+    ```
+    **Note we are using the "csharp-netcore" generator here, and that generator-specific arguments are specified with the pattern "--additional-properties=NAME=VALUE". See https://openapi-generator.tech/docs/generators/csharp-netcore/ for a list of all such options. The output directory used above is csharp-netcore as well. **  
+- This generates a whole solution including an empty tests project. However, only a few elements are needed for the final SDK project:
+    - The .csproj file contents (for nuget package references).
+    - The contents of "Api.EnrollmentComposites" folder
+    - The contents of "Client" folder
+    - The contents  of "Models.EnrollmentComposites" folder
 
 ## Legal Information
 


### PR DESCRIPTION
**Description**
- Added Microsoft.AspNetCore.WebUtilities package to help with building the uri for api calls. Added  BuildResponseUri method to ApiFacade to construct the know response url for the API call being made with the correct offset and limit values.
- Refactored the Handle method in ResponseHandleService to take in a responseUri argument and use that instead of the customized APiResponse's ResponseUri property.
- Added ApiRoutes to keep the api routes for different resources from the api. Refactored the services to construct the known responseUri and pass it to the response Handle call.
- Removed customizations to the generated SDK to get the response Uri from the current api call.
- Updated the README with information about the SDK generation steps.